### PR TITLE
A simple linear scaling strategy.

### DIFF
--- a/lib/autoscaler/linear_scaling_strategy.rb
+++ b/lib/autoscaler/linear_scaling_strategy.rb
@@ -1,0 +1,29 @@
+module Autoscaler
+  # Strategies determine the target number of workers
+  # The default strategy has a single worker when there is anything, or shuts it down.
+  class LinearScalingStrategy
+    #@param [integer] active_workers number of workers when in the active state.
+    def initialize(workers = 1, worker_capacity = 25)
+      @workers         = workers
+      @worker_capacity = worker_capacity
+    end
+
+    # @param [QueueSystem] system interface to the queuing system
+    # @param [Numeric] event_idle_time number of seconds since a job related event
+    # @return [Integer] target number of workers
+    def call(system, event_idle_time)
+      total_capacity   = (@workers * @worker_capacity).to_f
+      percent_capacity = total_work(system) / total_capacity
+
+      ideal_scale = (percent_capacity * @workers).ceil
+      max_scale   = @workers
+
+      return [ideal_scale, max_scale].min
+    end
+
+    private
+    def total_work(system)
+      system.queued + system.scheduled + system.retrying
+    end
+  end
+end

--- a/spec/autoscaler/linear_scaling_strategy_spec.rb
+++ b/spec/autoscaler/linear_scaling_strategy_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'test_system'
+require 'autoscaler/linear_scaling_strategy'
+
+describe Autoscaler::LinearScalingStrategy do
+  let(:cut) {Autoscaler::LinearScalingStrategy}
+
+  it "deactivates with no work" do
+    system = TestSystem.new(0)
+    strategy = cut.new(1)
+    strategy.call(system, 1).should == 0
+  end
+
+  it "activates with some work" do
+    system = TestSystem.new(1)
+    strategy = cut.new(1)
+    strategy.call(system, 1).should be > 0
+  end
+
+  it "minimally scales with minimal work" do
+    system = TestSystem.new(1)
+    strategy = cut.new(2, 2)
+    strategy.call(system, 1).should == 1
+  end
+
+  it "maximally scales with too much work" do
+    system = TestSystem.new(5)
+    strategy = cut.new(2, 2)
+    strategy.call(system, 1).should == 2
+  end
+
+  it "proportionally scales with some work" do
+    system = TestSystem.new(5)
+    strategy = cut.new(5, 2)
+    strategy.call(system, 1).should == 3
+  end
+end


### PR DESCRIPTION
A slightly more advanced scaling strategy, when BinaryScalingStrategy isn't enough. LinearScalingStrategy#new takes two parameters: number of workers, and per-worker job capacity. Total work is the sum of the queued, scheduled, and retrying jobs. The strategy scales to the minimum amount of workers to handle all of the jobs. No more than the maximum amount of workers are ever scaled to. The default worker capacity is 25, Sidekiq's default concurrency.
