### PR TITLE
LinearScalingStrategy shouldn't scale down paste the number of active workers

### DIFF
--- a/lib/autoscaler/linear_scaling_strategy.rb
+++ b/lib/autoscaler/linear_scaling_strategy.rb
@@ -18,7 +18,8 @@ module Autoscaler
       ideal_scale = (percent_capacity * @workers).ceil
       max_scale   = @workers
 
-      return [ideal_scale, max_scale].min
+      target = [ideal_scale, system.workers].max
+      return [max_scale, target].min
     end
 
     private

--- a/spec/autoscaler/linear_scaling_strategy_spec.rb
+++ b/spec/autoscaler/linear_scaling_strategy_spec.rb
@@ -34,4 +34,12 @@ describe Autoscaler::LinearScalingStrategy do
     strategy = cut.new(5, 2)
     strategy.call(system, 1).should == 3
   end
+
+  it "doesn't scale down past the number of active workers" do
+    system = TestSystem.new(0)
+    strategy = cut.new(5, 1)
+    strategy.call(system, 1).should == 0
+    system.define_singleton_method(:workers) { 2 }
+    strategy.call(system, 1).should == 2
+  end
 end


### PR DESCRIPTION
Before, LinearScalingStrategy didn't respect the number of current active workers - so, it could scale down workers that were still running a job, if the queue was empty.
