### PR TITLE
Strategy wrapper to ignore scheduled and retry queues, since those jobs may not be imminent.

### DIFF
--- a/lib/autoscaler/ignore_scheduled_and_retrying.rb
+++ b/lib/autoscaler/ignore_scheduled_and_retrying.rb
@@ -1,0 +1,13 @@
+module Autoscaler
+  class IgnoreScheduledAndRetrying
+    def initialize(strategy)
+      @strategy = strategy
+    end
+
+    def call(system, event_idle_time)
+      system.define_singleton_method(:scheduled) { 0 }
+      system.define_singleton_method(:retrying)  { 0 }
+      @strategy.call(system, event_idle_time)
+    end
+  end
+end

--- a/spec/autoscaler/ignore_scheduled_and_retrying_spec.rb
+++ b/spec/autoscaler/ignore_scheduled_and_retrying_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'test_system'
+require 'autoscaler/ignore_scheduled_and_retrying'
+
+describe Autoscaler::IgnoreScheduledAndRetrying do
+  let(:cut) {Autoscaler::IgnoreScheduledAndRetrying}
+
+  it "passes through enqueued" do
+    system = Struct.new(:enqueued).new(3)
+    strategy = proc {|system, time| system.enqueued}
+    cut.new(strategy).call(system, 0).should == 3
+  end
+
+  it "passes through workers" do
+    system = Struct.new(:workers).new(3)
+    strategy = proc {|system, time| system.workers}
+    cut.new(strategy).call(system, 0).should == 3
+  end
+
+  it "ignores scheduled" do
+    system = Struct.new(:scheduled).new(3)
+    strategy = proc {|system, time| system.scheduled}
+    cut.new(strategy).call(system, 0).should == 0
+  end
+
+  it "ignores retrying" do
+    system = Struct.new(:retrying).new(3)
+    strategy = proc {|system, time| system.retrying}
+    cut.new(strategy).call(system, 0).should == 0
+  end
+end
+
+


### PR DESCRIPTION
This is a wrapper around a Strategy that causes it to ignore it's system's retrying and scheduled methods (rather, it stubs them to zero.) This is useful so that future retries or scheduled jobs do not cause a worker to spin up and idle.
