### PR TITLE
Handles wrapped excon errors as heroku api errors

### DIFF
--- a/lib/autoscaler/heroku_scaler.rb
+++ b/lib/autoscaler/heroku_scaler.rb
@@ -60,14 +60,14 @@ module Autoscaler
 
     def heroku_get_workers
       client.get_ps(app).body.count {|ps| ps['process'].match /#{type}\.\d?/ }
-    rescue Excon::Errors::Error => e
+    rescue Excon::Errors::Error, Heroku::API::Errors::Error => e
       exception_handler.call(e)
       0
     end
 
     def heroku_set_workers(n)
       client.post_ps_scale(app, type, n)
-    rescue Excon::Errors::Error => e
+    rescue Excon::Errors::Error, Heroku::API::Errors::Error => e
       exception_handler.call(e)
     end
 


### PR DESCRIPTION
Yesterday, heroku api was down. We have lost a lot of our background jobs. For more details see my issue https://github.com/JustinLove/autoscaler/issues/30.
I saw, that you rescue from excon exceptions already, but it does not work for `Heroku::API::Errors` classes, which wrap excon errors. So, my code rescues from `Heroku::API::Errors::Error` class, which is the base class for all heroku api exceptions.
