### PR TITLE
Add support for worker type to CountercacheRedis

### DIFF
--- a/spec/autoscaler/counter_cache_redis_spec.rb
+++ b/spec/autoscaler/counter_cache_redis_spec.rb
@@ -18,6 +18,15 @@ describe Autoscaler::CounterCacheRedis do
     subject.counter.should == 2
   end
 
+  it 'does not conflict with multiple worker types' do
+    other_worker_cache = cut.new(@redis, 300, 'other_worker')
+    subject.counter = 1
+    other_worker_cache.counter = 2
+
+    subject.counter.should == 1
+    other_worker_cache.counter = 2
+  end
+
   it 'times out' do
     cache = cut.new(Sidekiq.method(:redis), 1) # timeout 0 invalid
     cache.counter = 3


### PR DESCRIPTION
Redis is a shared cache, and using it with multiple HerokuScalers
scaling different worker types causes wrong information to be cached.
This adds support for specifying the worker type, so individual caches
can be maintained.

By default HerokuScaler uses a new MemoryCounterCache, so no caches are
shared.
