### PR TITLE
Fix of "undefined method 'async' of nil class"

### DIFF
--- a/lib/autoscaler/sidekiq/monitor_middleware_adapter.rb
+++ b/lib/autoscaler/sidekiq/monitor_middleware_adapter.rb
@@ -25,7 +25,8 @@ module Autoscaler
         monitor.async.starting_job
         yield
       ensure
-        monitor.async.finished_job
+        # monitor might have gone, e.g. if Sidekiq has received SIGTERM
+        monitor.async.finished_job if monitor
       end
 
       private


### PR DESCRIPTION
Fix of ["undefined method 'async' of nil class"](https://github.com/JustinLove/autoscaler/issues/37) which may happen during Heroku dyno cycling.
