### PR TITLE
Count work currently being done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 gemfiles/*.gemfile.lock
 pkg/*
 doc/*
+.project

--- a/lib/autoscaler/binary_scaling_strategy.rb
+++ b/lib/autoscaler/binary_scaling_strategy.rb
@@ -20,7 +20,7 @@ module Autoscaler
 
     private
     def active?(system)
-      system.queued > 0 || system.scheduled > 0 || system.retrying > 0 || system.workers > 0
+      system.any_work?
     end
   end
 end

--- a/lib/autoscaler/linear_scaling_strategy.rb
+++ b/lib/autoscaler/linear_scaling_strategy.rb
@@ -29,7 +29,7 @@ module Autoscaler
 
     private
     def total_work(system)
-      system.workers + system.queued + system.scheduled + system.retrying
+      system.total_work
     end
   end
 end

--- a/lib/autoscaler/linear_scaling_strategy.rb
+++ b/lib/autoscaler/linear_scaling_strategy.rb
@@ -29,7 +29,7 @@ module Autoscaler
 
     private
     def total_work(system)
-      system.queued + system.scheduled + system.retrying
+      system.workers + system.queued + system.scheduled + system.retrying
     end
   end
 end

--- a/lib/autoscaler/sidekiq/entire_queue_system.rb
+++ b/lib/autoscaler/sidekiq/entire_queue_system.rb
@@ -25,6 +25,16 @@ module Autoscaler
         ::Sidekiq::RetrySet.new.size
       end
 
+      # @return [Boolean] if any kind of work still needs to be done
+      def any_work?
+        queued > 0 || scheduled > 0 || retrying > 0 || workers > 0
+      end
+
+      # @return [Integer] total amount of work
+      def total_work
+        queued + scheduled + retrying + workers
+      end
+
       # @return [Array[String]]
       def queue_names
         sidekiq_queues.keys

--- a/lib/autoscaler/sidekiq/sleep_wait_server.rb
+++ b/lib/autoscaler/sidekiq/sleep_wait_server.rb
@@ -36,7 +36,7 @@ module Autoscaler
       attr_reader :system
 
       def pending_work?
-        system.queued > 0 || system.scheduled > 0 || system.retrying > 0
+        system.workers > 0 || system.queued > 0 || system.scheduled > 0 || system.retrying > 0
       end
 
       def working!(queue, redis)

--- a/lib/autoscaler/sidekiq/sleep_wait_server.rb
+++ b/lib/autoscaler/sidekiq/sleep_wait_server.rb
@@ -36,7 +36,7 @@ module Autoscaler
       attr_reader :system
 
       def pending_work?
-        system.workers > 0 || system.queued > 0 || system.scheduled > 0 || system.retrying > 0
+        system.any_work?
       end
 
       def working!(queue, redis)

--- a/lib/autoscaler/sidekiq/specified_queue_system.rb
+++ b/lib/autoscaler/sidekiq/specified_queue_system.rb
@@ -32,6 +32,16 @@ module Autoscaler
         count_set(::Sidekiq::RetrySet.new)
       end
 
+      # @return [Boolean] if any kind of work still needs to be done
+      def any_work?
+        queued > 0 || scheduled > 0 || retrying > 0 || workers > 0
+      end
+
+      # @return [Integer] total amount of work
+      def total_work
+        queued + scheduled + retrying + workers
+      end
+
       # @return [Array[String]]
       attr_reader :queue_names
 


### PR DESCRIPTION
Avoid scaling down to zero when work is still being performed.