### PR TITLE
Make compatible with all Sidekiq versions 3 and up

### DIFF
--- a/autoscaler.gemspec
+++ b/autoscaler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "sidekiq", '~> 3.0'
+  s.add_runtime_dependency "sidekiq", '~> 3'
   s.add_runtime_dependency "heroku-api"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
with this small gemspec change, 3.0, 3.1, and 3.2 versions of Sidekiq should work with autoscaler.
