### PR TITLE
Optional customization of Heroku worker process name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,12 @@ source "http://rubygems.org"
 
 gemspec
 
-group :developent do
+group :development do
   gem 'rb-fsevent', '~> 0.9.1'
+end
+
+group :test do
+  gem 'rspec', "~> 2.99"
 end
 
 group :docs do

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This gem uses the [Heroku-Api](https://github.com/heroku/heroku.rb) gem, which r
     HEROKU_API_KEY=.....
     HEROKU_APP=....
 
+This gem assumes the name of the Heroku process to be 'worker' when it invokes the logic to scale Sidekiq up and down. You can optionally customize the name of the process with the following environment variable
+
+    SIDEKIQ_WORKER_NAME=....
+
 Install the middleware in your `Sidekiq.configure_` blocks
 
     require 'autoscaler/sidekiq'

--- a/lib/autoscaler/heroku_scaler.rb
+++ b/lib/autoscaler/heroku_scaler.rb
@@ -7,10 +7,10 @@ module Autoscaler
     # @param [String] type process type this scaler controls
     # @param [String] key Heroku API key
     # @param [String] app Heroku app name
-    def initialize(
-        type = 'worker',
-        key = ENV['HEROKU_API_KEY'],
-        app = ENV['HEROKU_APP'])
+    def initialize( 
+        type = ENV['SIDEKIQ_WORKER_NAME'] || 'worker',
+        key  = ENV['HEROKU_API_KEY'],
+        app  = ENV['HEROKU_APP'])
       @client = Heroku::API.new(:api_key => key)
       @type = type
       @app = app

--- a/spec/autoscaler/heroku_scaler_spec.rb
+++ b/spec/autoscaler/heroku_scaler_spec.rb
@@ -2,48 +2,63 @@ require 'spec_helper'
 require 'autoscaler/heroku_scaler'
 require 'heroku/api/errors'
 
-describe Autoscaler::HerokuScaler, :online => true do
+describe Autoscaler::HerokuScaler do
   let(:cut) {Autoscaler::HerokuScaler}
   let(:client) {cut.new}
   subject {client}
 
-  its(:workers) {should == 0}
+  describe "initialization" do
+    let(:worker_name){ "not_worker" }
 
-  describe 'scaled' do
     around do |example|
-      client.workers = 1
+      ENV['SIDEKIQ_WORKER_NAME'] = worker_name
       example.yield
-      client.workers = 0
+      ENV['SIDEKIQ_WORKER_NAME'] = nil
     end
+    
+    its(:type) { should == worker_name }  
+  end   
 
-    its(:workers) {should == 1}
-  end
+  describe "online", :online => true do
+    its(:workers) {should == 0}
+    its(:type) { should == "worker" } 
 
-  shared_examples 'exception handler' do |exception_class|
-    before do
-      client.should_receive(:client){
-        raise exception_class.new(Exception.new('oops'))
-      }
-    end
-
-    describe "default handler" do
-      it {expect{client.workers}.to_not raise_error}
-      it {client.workers.should == 0}
-      it {expect{client.workers = 2}.to_not raise_error}
-    end
-
-    describe "custom handler" do
-      before do
-        @caught = false
-        client.exception_handler = lambda {|exception| @caught = true}
+    describe 'scaled' do
+      around do |example|
+        client.workers = 1
+        example.yield
+        client.workers = 0
       end
 
-      it {client.workers; @caught.should be_true}
+      its(:workers) {should == 1}
+    end
+
+    shared_examples 'exception handler' do |exception_class|
+      before do
+        client.should_receive(:client){
+          raise exception_class.new(Exception.new('oops'))
+        }
+      end
+
+      describe "default handler" do
+        it {expect{client.workers}.to_not raise_error}
+        it {client.workers.should == 0}
+        it {expect{client.workers = 2}.to_not raise_error}
+      end
+
+      describe "custom handler" do
+        before do
+          @caught = false
+          client.exception_handler = lambda {|exception| @caught = true}
+        end
+
+        it {client.workers; @caught.should be_true}
+      end
+    end
+
+    describe 'exception handling', :focus => true do
+      it_behaves_like 'exception handler', Excon::Errors::SocketError
+      it_behaves_like 'exception handler', Heroku::API::Errors::Error
     end
   end
-
-  describe 'exception handling', :focus => true do
-    it_behaves_like 'exception handler', Excon::Errors::SocketError
-    it_behaves_like 'exception handler', Heroku::API::Errors::Error
-  end
-end
+end  


### PR DESCRIPTION
This pull request adds support for a custom process name in Heroku for the Sidekiq worker. The default logic looks for a process named 'worker' but with this change, a SIDEKIQ_WORKER_NAME environment variable can be set to over-ride this name. 

I ran into some issues running the specs with a vanilla bundle install on this repo. The latest 3.x version of rspec installed by default and required some refactoring to the spec code, so I pinned the version at the latest 2.x version which cleared up at least some of my issues. I was never able to get the entire test suite passing on master, so I'd be curious to know which versions of everything are required in order for that to happen. I would be willing to help with getting this gem set up on TravisCI if I could get more information on at least getting all green on my specs locally. To be clear I did see the tests I wrote for this change passing. 

I also fixed a typo in the the Gemfile which I think was preventing rb-fsevent from ever loading.  