### PR TITLE
A NonThreadServer to scale down the workers

### DIFF
--- a/lib/autoscaler/sidekiq/non_thread_server.rb
+++ b/lib/autoscaler/sidekiq/non_thread_server.rb
@@ -1,0 +1,22 @@
+require 'autoscaler/sidekiq/sleep_wait_server'
+
+module Autoscaler
+  module Sidekiq
+    # Sidekiq server middleware
+    # Monitor the sidekiq server for scale-down
+    class NonThreadServer < SleepWaitServer
+
+      private
+      def wait_for_task_or_scale(redis)
+        while idle?(redis) || !pending_work?
+          sleep(1)
+        end
+        @scaler.workers = 0 if last_work?
+      end
+
+      def last_work?
+        @scaler.workers >= 1 && system.total_work == 1
+      end
+    end
+  end
+end

--- a/lib/autoscaler/sidekiq/sleep_wait_server.rb
+++ b/lib/autoscaler/sidekiq/sleep_wait_server.rb
@@ -9,7 +9,7 @@ module Autoscaler
       # @param [scaler] scaler object that actually performs scaling operations (e.g. {HerokuPlatformScaler})
       # @param [Numeric] timeout number of seconds to wait before shutdown
       # @param [Array[String]] specified_queues list of queues to monitor to determine if there is work left.  Defaults to all sidekiq queues.
-      def initialize(scaler, timeout, specified_queues = nil)
+      def initialize(scaler, timeout = 60, specified_queues = nil)
         @scaler  = scaler
         @timeout = timeout
         @system  = QueueSystem.new(specified_queues)


### PR DESCRIPTION
The deafult `ThreadServer` is raising a lot of `ThreadError: can't create Thread: Resource temporarily unavailable`, so, I develop a simple NonThreadError based on SleepWaitServer.

And why not use the `SleepWaitServer`?
Because it wasn't scaling down the workers, so I make it a little different.
## Example

`sidekiq.rb`

``` ruby
require 'sidekiq'
require 'autoscaler/sidekiq'
require 'autoscaler/heroku_scaler'
require 'autoscaler/sidekiq/non_thread_server'

heroku = nil
if ENV['HEROKU_API_KEY'].present?
  heroku = Autoscaler::HerokuScaler.new('worker')
end

Sidekiq.configure_client do |config|
  if heroku
    config.client_middleware do |chain|
      chain.add(Autoscaler::Sidekiq::Client, { 'default' => heroku })
    end
  end
end

Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    if heroku
      p "Setting up auto-scaledown"
      chain.add(Autoscaler::Sidekiq::NonThreadServer, heroku)
    else
      p "Not scaleable"
    end
  end
end
```
