### PR TITLE
Upgrading Sidekiq version

### DIFF
--- a/autoscaler.gemspec
+++ b/autoscaler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.1'
 
-  s.add_runtime_dependency "sidekiq", '~> 5.0'
+  s.add_runtime_dependency "sidekiq", '~> 6.0'
   s.add_runtime_dependency "platform-api", '~> 2.0'
 
   s.add_development_dependency "bundler", '~> 1.0'


### PR DESCRIPTION
Since Sidekiq launched version 6, autoscaler can update the dependency version with no breaking changes. Also, the `rack` gem [has a security vulnerability](https://groups.google.com/forum/#!topic/ruby-security-ann/T4ZIsfRf2eA) for versions lower than 2.2.0. As Sidekiq only supports those rack versions on version 6, this upgrade solves this issue.